### PR TITLE
Better layout for mobile

### DIFF
--- a/priv/static/css/styles.css
+++ b/priv/static/css/styles.css
@@ -35,3 +35,7 @@ footer {
   margin-bottom: 220px;
   clear: both;
 }
+
+.col-data {
+  flex-grow: 2.5;
+}

--- a/priv/templates/apple_captive_portal.html.eex
+++ b/priv/templates/apple_captive_portal.html.eex
@@ -1,7 +1,7 @@
 <HTML>
   <HEAD>
     <TITLE>Captive Portal</TITLE>
-    <META http-equiv="refresh" content="0; url=<%= dns_name %>">
+    <META http-equiv="refresh" content="0; url=<%= dns_name %>" name="viewport" content="width=device-width, initial-scale=1">
   </HEAD>
   <BODY>
     <p>Redirecting to Network Setup...</p>

--- a/priv/templates/apple_captive_portal.html.eex
+++ b/priv/templates/apple_captive_portal.html.eex
@@ -1,7 +1,8 @@
 <HTML>
   <HEAD>
     <TITLE>Captive Portal</TITLE>
-    <META http-equiv="refresh" content="0; url=<%= dns_name %>" name="viewport" content="width=device-width, initial-scale=1">
+    <META http-equiv="refresh" content="0; url=<%= dns_name %>">
+    <META name="viewport" content="width=device-width, initial-scale=1">
   </HEAD>
   <BODY>
     <p>Redirecting to Network Setup...</p>

--- a/priv/templates/apply.html.eex
+++ b/priv/templates/apply.html.eex
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">

--- a/priv/templates/apply.html.eex
+++ b/priv/templates/apply.html.eex
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
@@ -25,8 +25,8 @@
        <div class="container">
          <%= for {info_name, info_data} <- device_info do %>
            <div class="row">
-             <strong class="col-sm-2"><%= info_name %></strong>
-             <span class="col"><%= info_data %></span>
+             <strong class="col"><%= info_name %></strong>
+             <span class="col col-data"><%= info_data %></span>
            </div>
          <% end %>
      </footer>

--- a/priv/templates/complete.html.eex
+++ b/priv/templates/complete.html.eex
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
@@ -18,8 +18,8 @@
        <div class="container">
          <%= for {info_name, info_data} <- device_info do %>
            <div class="row">
-             <strong class="col-sm-2"><%= info_name %></strong>
-             <span class="col"><%= info_data %></span>
+             <strong class="col"><%= info_name %></strong>
+             <span class="col col-data"><%= info_data %></span>
            </div>
          <% end %>
      </footer>

--- a/priv/templates/complete.html.eex
+++ b/priv/templates/complete.html.eex
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">

--- a/priv/templates/configure_enterprise.html.eex
+++ b/priv/templates/configure_enterprise.html.eex
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">

--- a/priv/templates/configure_enterprise.html.eex
+++ b/priv/templates/configure_enterprise.html.eex
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
@@ -44,8 +44,8 @@
       <div class="container">
         <%= for {info_name, info_data} <- device_info do %>
           <div class="row">
-            <strong class="col-sm-2"><%= info_name %></strong>
-            <span class="col"><%= info_data %></span>
+            <strong class="col"><%= info_name %></strong>
+             <span class="col col-data"><%= info_data %></span>
           </div>
         <% end %>
     </footer>

--- a/priv/templates/configure_password.html.eex
+++ b/priv/templates/configure_password.html.eex
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
@@ -40,8 +40,8 @@
       <div class="container">
         <%= for {info_name, info_data} <- device_info do %>
           <div class="row">
-            <strong class="col-sm-2"><%= info_name %></strong>
-            <span class="col"><%= info_data %></span>
+            <strong class="col"><%= info_name %></strong>
+             <span class="col col-data"><%= info_data %></span>
           </div>
         <% end %>
     </footer>

--- a/priv/templates/configure_password.html.eex
+++ b/priv/templates/configure_password.html.eex
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">

--- a/priv/templates/index.html.eex
+++ b/priv/templates/index.html.eex
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">

--- a/priv/templates/index.html.eex
+++ b/priv/templates/index.html.eex
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
@@ -59,10 +59,10 @@
 
        </div>
 
-       <a class="btn btn-primary" href="/networks">Add a New Network</a>
+       <a class="btn btn-primary m-1" href="/networks">Add a New Network</a>
        <%= if length(configs) > 0 do %>
-         <a class="btn btn-primary" href="/apply">Apply configuration</a>
-         <a class="btn btn-secondary" href="/complete" title="This will apply the configuration without any attempt to verify a successful network connection.">Complete Without Verification</a>
+         <a class="btn btn-primary m-1" href="/apply">Apply configuration</a>
+         <a class="btn btn-secondary m-1" href="/complete" title="This will apply the configuration without any attempt to verify a successful network connection.">Complete Without Verification</a>
        <% end %>
      </div>
 
@@ -70,8 +70,8 @@
        <div class="container">
          <%= for {info_name, info_data} <- device_info do %>
            <div class="row">
-             <strong class="col-sm-2"><%= info_name %></strong>
-             <span class="col"><%= info_data %></span>
+             <strong class="col"><%= info_name %></strong>
+             <span class="col col-data"><%= info_data %></span>
            </div>
          <% end %>
      </footer>

--- a/priv/templates/network_new.html.eex
+++ b/priv/templates/network_new.html.eex
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
@@ -35,8 +35,8 @@
        <div class="container">
          <%= for {info_name, info_data} <- device_info do %>
            <div class="row">
-             <strong class="col-sm-2"><%= info_name %></strong>
-             <span class="col"><%= info_data %></span>
+             <strong class="col"><%= info_name %></strong>
+             <span class="col col-data"><%= info_data %></span>
            </div>
          <% end %>
      </footer>

--- a/priv/templates/network_new.html.eex
+++ b/priv/templates/network_new.html.eex
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">

--- a/priv/templates/networks.html.eex
+++ b/priv/templates/networks.html.eex
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
@@ -40,8 +40,8 @@
        <div class="container">
          <%= for {info_name, info_data} <- device_info do %>
            <div class="row">
-             <strong class="col-sm-2"><%= info_name %></strong>
-             <span class="col"><%= info_data %></span>
+             <strong class="col"><%= info_name %></strong>
+             <span class="col col-data"><%= info_data %></span>
            </div>
          <% end %>
         </div>

--- a/priv/templates/networks.html.eex
+++ b/priv/templates/networks.html.eex
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>VintageNet Wizard</title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">


### PR DESCRIPTION
By just inserting `name="viewport" content="width=device-width, initial-scale=1"`, the result is acceptable.
I made two further improvements:

- Introduced a`flex-grow` for the right column of the bottom bar to align the two columns on the same row (avoiding in this way a huge bottom bar on mobile)

- Added a small `margin` to a group of three buttons in one page, since on mobile they appear one below the other and no margin between them was present.